### PR TITLE
Fix logic to correctly detect Amazon Linux version

### DIFF
--- a/bin/wkhtmltopdf
+++ b/bin/wkhtmltopdf
@@ -27,10 +27,10 @@ suffix = case RbConfig::CONFIG['host_os']
            os = 'ubuntu_20.04' if os.start_with?('ubuntu_20.') ||
                                   os.start_with?('ubuntu_21.')
 
-           os = 'centos_6' if (os.start_with?('amzn_') && !os.start_with?('amzn_2')) ||
+           os = 'centos_6' if (os.start_with?('amzn_') && os != 'amzn_2') ||
                               (os.empty? && File.read('/etc/centos-release').start_with?('CentOS release 6'))
 
-           os = 'centos_7' if os.start_with?('amzn_2') ||
+           os = 'centos_7' if (os.start_with?('amzn_2') && !os.start_with?('amzn_20')) ||
                               os.start_with?('rhel_7.')
 
            os_based_on_debian_9 = os.start_with?('debian_9') ||


### PR DESCRIPTION
Amazon Linux 2 os strings is "amzn_2" and Amazon Linux 1 os string version ID includes the year, for example: "amzn_2016.9".
This was causing all Amazon Linux to detect the binary as if it were Amazon Linux 2 and therefore failing on Amazon Linux 1.
This PR fixes the logic to make the detection work for both versions.